### PR TITLE
Fixed error after admin page was not shown.

### DIFF
--- a/app/code/community/Hackathon/CopyStoreData/etc/adminhtml.xml
+++ b/app/code/community/Hackathon/CopyStoreData/etc/adminhtml.xml
@@ -13,6 +13,9 @@
     </menu>
     <acl>
         <resources>
+            <all>
+                <title>Allow Everything</title>
+            </all>
             <admin>
                 <children>
                     <system>


### PR DESCRIPTION
The page where you can setup sync accross store views was not shown (404 error).

See: https://magento.stackexchange.com/questions/198389/custom-module-admin-panel-section-gives-404-error-on-save